### PR TITLE
empty referer when browsing straight to /login

### DIFF
--- a/controllers/UserController.js
+++ b/controllers/UserController.js
@@ -48,7 +48,16 @@ userController = {
                 }
             });
         }else{
-            req.session.refUrl=req.headers.referer;
+            if(req.headers.referer !== null && req.headers.referer !== undefined)
+            {
+                console.log("setting referer to: "+req.headers.referer);
+                req.session.refUrl=req.headers.referer;
+            }
+            else
+            {
+                console.log("setting referer to: /");
+                req.session.refUrl="/";
+            }
             res.render("login",{title:"login"});
         }
     },


### PR DESCRIPTION
when a user browses directly to /login the refUrl was being set to "undefined", which fatalled when redirecting
